### PR TITLE
fix : Card 타입인 객체만 골라서 map에 넘기도록 함(타입 좁히기)

### DIFF
--- a/screens/Mypage/BookMark.tsx
+++ b/screens/Mypage/BookMark.tsx
@@ -57,10 +57,10 @@ export default function BookMarkScreen() {
                 }}>Bookmark List</Text>
 
             <ScrollView>
-                {bookmarkedCard.map((item) => {
-                    console.log('id확인', item._id)
-                    return (
-                        <View>
+                {bookmarkedCard
+                    .filter((item): item is Card => item !== null && item !== undefined && typeof item === 'object')
+                    .map((item) => (
+                        <View key={item.cardId}>
                             <InfoCard
                                 _id={item.cardId}
                                 image={item.image}
@@ -72,8 +72,8 @@ export default function BookMarkScreen() {
                                 }}
                             />
                         </View>
-                    );
-                })}
+                    ))}
+
             </ScrollView>
         </View>
     );

--- a/screens/Practice/SelectTestScreen.tsx
+++ b/screens/Practice/SelectTestScreen.tsx
@@ -120,6 +120,7 @@ const styles = StyleSheet.create({
         fontFamily: "Pretendard-bold",
     },
     contentContainer: {
+        marginTop: 29,
         width: 335, borderRadius: 12,
         shadowColor: '#000',
         shadowOffset: { width: 0, height: 1 },


### PR DESCRIPTION
북마크 페이지에서 `Uncaught TypeError: Cannot read properties of null (reading '_id')`라는 에러가 뜸..
알고보니 `item._id`가 `null`이거나 `undefined`인 상태에서 접근 시도했기 때문이다. 그래서 다음과 같이 타입 내로잉을 통해 map돌리기 전에 `Card 타입인 객체만 골라서 필터링` 해 주었다. (잘못된 값 섞여 있을 수도 잇기에 사전에 확인함)

> 이 부분 추가✅ (fiter, 타입 가드 사용!!)
`.filter((item): item is Card => item !== null && item !== undefined && typeof item === 'object')
`
- item is Card : 타입 가드, item이 true이면 Card 타입이라고 간주
- item !== null && item !== undefined && typeof item === 'object'
- ㄴ> item이 null, undefined, 혹은 기본형(string, number 등)이 아닌지 확인하는 조건임
- ㄴ-> 여기서 object는 배열이나 일반 객체를 포함한 넓은 의미의 객체를 의미한다.
