### PR TITLE
feat : 호주 시간과 날짜 가져오기

### DIFF
--- a/components/common/Time.tsx
+++ b/components/common/Time.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+export default function Time() {
+    dayjs.extend(utc)
+    dayjs.extend(timezone)
+    const getAusTime = () => {
+        return dayjs().tz("Australia/Sydney").format("hh:mm a")
+    }
+    const getAusDay = () => {
+        return dayjs().tz("Australia/Sydney").format("MMMM D, YYYY (ddd)");
+    }
+    return (
+        <View>
+            <Text>{getAusTime()}</Text>
+            <Text>{getAusDay()}</Text>
+        </View>
+    )
+}


### PR DESCRIPTION
[day.js - 날짜 라이브러리](https://velog.io/@hongsoom/Library-day.js-%EB%82%A0%EC%A7%9C-%EB%9D%BC%EC%9D%B4%EB%B8%8C%EB%9F%AC%EB%A6%AC)

- `extend` : 기능 활성화 시킴
- `utc` :  (세계 표준시)
- `tz(time zone)` : 특정 시간대로 변환할 수 있음